### PR TITLE
check location services for ble

### DIFF
--- a/app/src/main/java/de/uni_osnabrueck/ikw/eegdroid/DeviceScanActivity.java
+++ b/app/src/main/java/de/uni_osnabrueck/ikw/eegdroid/DeviceScanActivity.java
@@ -25,6 +25,7 @@ import android.location.LocationManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -211,32 +212,42 @@ public class DeviceScanActivity extends ListActivity {
     }
 
 
-    // TODO: Implement LocationEnabledCheck
     private void checkLocationEnabled(){
 
         Context context = this;
         LocationManager lm = (LocationManager)context.getSystemService(Context.LOCATION_SERVICE);
-        boolean gps_enabled = false;
-        boolean network_enabled = false;
+        boolean gpsEnabled = false;
+        boolean networkEnabled = false;
+        boolean locationEnabled = false;
 
         try {
-            gps_enabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
-            Log.d(TAG, "Gps enabled checked!: " + gps_enabled);
+            gpsEnabled = lm.isProviderEnabled(LocationManager.GPS_PROVIDER);
+            Log.d(TAG, "Gps enabled checked!: " + gpsEnabled);
         } catch(Exception ex) {}
 
         try {
-            network_enabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
+            networkEnabled = lm.isProviderEnabled(LocationManager.NETWORK_PROVIDER);
         } catch(Exception ex) {}
 
-        if(!gps_enabled || !network_enabled) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            locationEnabled = lm.isLocationEnabled();
+        } else {
+            // This was deprecated in API 28
+            int mode = Settings.Secure.getInt(context.getContentResolver(), Settings.Secure.LOCATION_MODE,
+                    Settings.Secure.LOCATION_MODE_OFF);
+            locationEnabled = (mode != Settings.Secure.LOCATION_MODE_OFF);
+        }
+
+        if(!locationEnabled && !networkEnabled && !gpsEnabled) {
             // notify user
             Log.d(TAG, "Actually Got into the path where user is notified about location services.");
             new AlertDialog.Builder(context)
-                    .setMessage("Location Services Disabled")
-                    .setPositiveButton("Bluetooth Low Energy Requires enabled location services.", new DialogInterface.OnClickListener() {
+                    .setTitle("Location Services Disabled")
+                    .setMessage("Bluetooth Low Energy Requires enabled location services.")
+                    .setPositiveButton("Enable Location Service", new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface paramDialogInterface, int paramInt) {
-                            context.startActivity(new Intent(Settings.LOCATION_SERVICE));
+                            context.startActivity(new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS));
                         }
                     })
                             .setNegativeButton("Cancel",null)


### PR DESCRIPTION
Location Services are cheked when launching the device scan activity. If location services are disabled, user is prompted to enable them